### PR TITLE
Return null when user not found in UserService.getUserById

### DIFF
--- a/api/test/service.user.test.ts
+++ b/api/test/service.user.test.ts
@@ -31,5 +31,14 @@ describe("User service", () => {
       expect(result).to.be.null;
       expect(loggerStub.error.calledOnce).to.be.true;
     });
+
+    it("should return null when user was not found on getUserById", async() => {
+      sinon.stub(userRepositoryStub, "findOne").resolves(null);
+
+      let result = await userService.getUserById(Number.MAX_SAFE_INTEGER);
+
+      expect(result).to.be.null;
+      expect(loggerStub.error.notCalled).to.be.true;
+    });
   });
 });

--- a/service/UserService.ts
+++ b/service/UserService.ts
@@ -57,6 +57,9 @@ export default class UserService {
           id: userId,
         },
       });
+      if (!user) {
+        return null;
+      }
       const result = Object.assign({}, user);
       delete result.password;
       return result;


### PR DESCRIPTION
### Motivation
- Fix a bug where `UserService.getUserById` could produce an object instead of `null` when no user was found, causing callers to treat a missing user as a valid value.

### Description
- Add an explicit `if (!user) return null;` check in `UserService.getUserById` to return `null` when the repository lookup yields no result.
- Add a regression test in `api/test/service.user.test.ts` that stubs `findOne` to resolve `null` and asserts `getUserById` returns `null` and does not log an error.

### Testing
- Ran `npm run build`, which completed successfully.
- Attempted `npm run mtest:api`, but the test run aborts in setup with `TypeError: Invalid URL` from the Postgres connection due to a missing/invalid test DB URL, so the full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2d3cd9188324a025fefb983413cf)