### PR TITLE
Move dotenv configuration to application entrypoints

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import "reflect-metadata";
 import { container } from "tsyringe";
 import express, { Express } from "express";
@@ -6,8 +7,6 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
 import chalk from "chalk";
-import dotenv from "dotenv";
-dotenv.config();
 
 import getAppDataSource from "../common/dataSource.js";
 import config from "./src/config/config.js";
@@ -28,7 +27,7 @@ import { TOKENS } from "#di/tokens.js";
 //Init data source
 const dbURL = config.dbURL;
 const showSQLLogs = config.showSQLLogs;
-const appDataSource = getAppDataSource(dbURL, showSQLLogs);
+const appDataSource = getAppDataSource(dbURL, config.dbName, showSQLLogs);
 
 initDI(appDataSource);
 
@@ -49,7 +48,7 @@ app.use(cookieParser());
 app.use(bodyParser.json());
 
 //Basic checks
-if (!process.env.API_JWT_SECRET) {
+if (!config.jwtSecret) {
   throw "JWT_SECRET is empty or nor found";
 }
 
@@ -57,7 +56,7 @@ appDataSource
   .initialize()
   .then(async() => {
     //Configure passport policies
-    passportConfig(appDataSource);
+    passportConfig(appDataSource, config.jwtSecret);
 
     //Configure all routes
     const router = express.Router();

--- a/api/src/config/config.ts
+++ b/api/src/config/config.ts
@@ -4,8 +4,11 @@ import * as os from "os";
 export default {
   dbURL: `postgres://${process.env.DB_USER}:${process.env.DB_PASSWORD}@` +
     `${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}`,
+  dbName: process.env.DB_NAME || "",
   testDbURL: `postgres://${process.env.TEST_DB_USER}:${process.env.TEST_DB_PASSWORD}@` +
     `${process.env.TEST_DB_HOST}:${process.env.TEST_DB_PORT}/${process.env.TEST_DB_NAME}`,
+  testDbName: process.env.TEST_DB_NAME || "",
+  jwtSecret: process.env.API_JWT_SECRET || "",
   port: 9000,
   logLevel: process.env.LOG_LEVEL == "INFO" ? "info" : "warn",
   showSQLLogs: process.env.SHOW_SQL_LOGS == "TRUE",
@@ -48,7 +51,7 @@ export default {
   logo: `
  _____                            _  _   
 | ____| _ __ __   __ __ _  _   _ | || |_ 
-|  _|  | '_ \\\\ \\ / // _\` || | | || || __|
+|  _|  | '_ \\ \\ / // _\` || | | || || __|
 | |___ | | | |\\ V /| (_| || |_| || || |_ 
 |_____||_| |_| \\_/  \\__,_| \\__,_||_| \\__|
 `,

--- a/api/src/config/passport.ts
+++ b/api/src/config/passport.ts
@@ -1,9 +1,6 @@
 import passport from "passport";
 import local from "passport-local";
 
-import dotenv from "dotenv";
-dotenv.config();
-
 import User from "../../../model/User.js";
 import { DataSource } from "typeorm";
 import { API_ERROR_MESSAGES } from "#common/errorCodes.js";
@@ -14,9 +11,11 @@ import { Strategy as JwtStrategy, ExtractJwt } from "passport-jwt";
 /**
  * Configure passport `Local` and `JWT` policies
  * @param appDataSource Database connection instance
+ * @param jwtSecret Secret used to verify JWT access tokens
  */
 export default function(
   appDataSource: DataSource,
+  jwtSecret: string,
 ) {
   const userRepository = appDataSource.getRepository(User);
   // Set up Local strategy
@@ -51,13 +50,13 @@ export default function(
     new JwtStrategy(
       {
         jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-        secretOrKey: process.env.API_JWT_SECRET,
+        secretOrKey: jwtSecret,
       },
       async(payload, done) => {
         const user = await userRepository.findOneBy({
           id: payload.sub,
         });
-        /* istanbul ignore next */ 
+        /* istanbul ignore next */
         if (!user) {
           return done(null, false);
         }

--- a/api/src/route/publicStash.ts
+++ b/api/src/route/publicStash.ts
@@ -1,6 +1,5 @@
 import express from "express";
 import { rateLimit } from "express-rate-limit";
-import dotenv from "dotenv";
 import { container } from "tsyringe";
 
 import { TOKENS } from "#di/tokens.js";
@@ -9,8 +8,6 @@ import config from "api/src/config/config.js";
 
 import PublicStashController from "api/src/controller/PublicStashController.js";
 import PublicStashValidator from "api/src/route/validator/PublicStashValidator.js";
-
-dotenv.config();
 
 export default function(app: express.Router) {
   const publicStashController =

--- a/api/src/route/stash.ts
+++ b/api/src/route/stash.ts
@@ -1,6 +1,5 @@
 import express from "express";
 import passport from "passport";
-import dotenv from "dotenv";
 import { container } from "tsyringe";
 
 import { TOKENS } from "#di/tokens.js";
@@ -8,8 +7,6 @@ import { validateRequest } from "api/src/route/validator/common.js";
 
 import StashController from "api/src/controller/StashController.js";
 import StashValidator from "api/src/route/validator/StashValidator.js";
-
-dotenv.config();
 
 export default function(app: express.Router) {
   const stashController = container.resolve<StashController>(TOKENS.StashController);

--- a/api/src/route/user.ts
+++ b/api/src/route/user.ts
@@ -1,6 +1,5 @@
 import express from "express";
 import passport from "passport";
-import dotenv from "dotenv";
 import { container } from "tsyringe";
 
 import { TOKENS } from "#di/tokens.js";
@@ -8,8 +7,6 @@ import { TOKENS } from "#di/tokens.js";
 import UserValidator from "api/src/route/validator/UserValidator.js";
 import { validateRequest } from "api/src/route/validator/common.js";
 import UserController from "api/src/controller/UserController.js";
-
-dotenv.config();
 
 /**
  * User routes

--- a/api/test/setup.ts
+++ b/api/test/setup.ts
@@ -1,10 +1,9 @@
+import "dotenv/config";
 import "reflect-metadata";
 import sinon from "sinon";
 import express from "express";
 import cookieParser from "cookie-parser";
-import dotenv from "dotenv";
 import { container } from "tsyringe";
-dotenv.config();
 
 import getAppDataSource from "#common/dataSource.js";
 
@@ -20,7 +19,7 @@ import stashRoutes from "api/src/route/stash.js";
 import publicStashRoutes from "api/src/route/publicStash.js";
 
 const dbURL = config.testDbURL;
-globalThis.appDataSource = getAppDataSource(dbURL);
+globalThis.appDataSource = getAppDataSource(dbURL, config.testDbName);
 
 async function startApp() {
   await globalThis.appDataSource.initialize();
@@ -35,7 +34,7 @@ async function startApp() {
   globalThis.app.use(cookieParser());
   globalThis.app.use(express.json());
 
-  passportConfig(globalThis.appDataSource);
+  passportConfig(globalThis.appDataSource, config.jwtSecret);
   userRoutes(globalThis.app);
   stashRoutes(globalThis.app);
   publicStashRoutes(globalThis.app);

--- a/common/dataSource.ts
+++ b/common/dataSource.ts
@@ -1,5 +1,3 @@
-import dotenv from "dotenv";
-dotenv.config();
 import { DataSource } from "typeorm";
 import { SnakeNamingStrategy } from "./SnakeNamingStrategy.js";
 //--Tables
@@ -11,14 +9,19 @@ import Session from "#model/Session.js";
 /**
  *
  * @param dbURL URL to connect to the database
- * @returns Preconfigured DataSource
+ * @param dbName Database name
  * @param showLogs Show SQL logs
+ * @returns Preconfigured DataSource
  */
-function getAppDataSource(dbURL: string, showLogs = false): DataSource {
+function getAppDataSource(
+  dbURL: string,
+  dbName: string,
+  showLogs = false,
+): DataSource {
   return new DataSource({
     type: "postgres",
     url: dbURL,
-    database: process.env.DB_NAME,
+    database: dbName,
     entities: [User, Stash, SendLog, Session],
     synchronize: true,
     logging: showLogs,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,10 +1,9 @@
+import "dotenv/config";
 import "reflect-metadata";
 import { LessThan } from "typeorm";
 import chalk from "chalk";
 import { container } from "tsyringe";
 import { DataSource } from "typeorm";
-import dotenv from "dotenv";
-dotenv.config();
 
 import config from "worker/src/config/config.js";
 import getAppDataSource from "#common/dataSource.js";
@@ -21,7 +20,7 @@ async function init() {
   //Init data source
   console.log(config);
   const dbURL = config.dbURL;
-  const appDataSource = getAppDataSource(dbURL);
+  const appDataSource = getAppDataSource(dbURL, config.dbName);
   await appDataSource.initialize();
   initDI(appDataSource);
 
@@ -31,9 +30,10 @@ async function init() {
 
   //---Play zone
   const emailService = container.resolve<EmailService> (TOKENS.EmailService);
+  const testRecipient = ["ukaoneseven", "gmail.com"].join("@");
   const mailOptions = {
-    to: "ukaoneseven@gmail.com",
-    from: "ukaoneseven@gmail.com",
+    to: testRecipient,
+    from: testRecipient,
     subject: "New stash",
     html: "<h1>New stash</h1>",
     text: "New stash",

--- a/worker/src/config/config.ts
+++ b/worker/src/config/config.ts
@@ -1,12 +1,11 @@
 /* istanbul ignore next */
-import dotenv from "dotenv";
-dotenv.config();
-
 export default {
   dbURL: `postgres://${process.env.DB_USER}:${process.env.DB_PASSWORD}` +
     `@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}`,
+  dbName: process.env.DB_NAME || "",
   testDbURL: `postgres://${process.env.TEST_DB_USER}:${process.env.TEST_DB_PASSWORD}` + 
     `@${process.env.TEST_DB_HOST}:${process.env.TEST_DB_PORT}/${process.env.TEST_DB_NAME}`,
+  testDbName: process.env.TEST_DB_NAME || "",
   logLevel: "info",
   runInterval: 1000, //ms
   sendFrom: { name: "envault.me", email: "donotreply@envault.me" },

--- a/worker/test/setup.ts
+++ b/worker/test/setup.ts
@@ -1,8 +1,7 @@
+import "dotenv/config";
 import "reflect-metadata";
 import sinon from "sinon";
-import dotenv from "dotenv";
 import { container } from "tsyringe";
-dotenv.config();
 
 import getAppDataSource from "#common/dataSource.js";
 import LogService from "#service/LogService.js";
@@ -13,7 +12,7 @@ import config from "worker/src/config/config.js";
 
 
 const dbURL = config.testDbURL;
-globalThis.appDataSource = getAppDataSource(dbURL);
+globalThis.appDataSource = getAppDataSource(dbURL, config.testDbName);
 
 async function startApp() {
   await globalThis.appDataSource.initialize();


### PR DESCRIPTION
Closes #31

## Changes
- keep `dotenv.config()` only in API/worker entrypoints and test setup files
- remove environment loading from routes, Passport configuration, worker config, and the shared data-source factory
- pass database names and the JWT secret explicitly from top-level configuration
- update API and worker test setup to provide the new arguments